### PR TITLE
Adiciona verificador para casos especiais (sete exceções)

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,8 @@ var irregulars = {
   ]
 };
 
+var seteExcecoes = ['mal', 'cônsul', 'mel', 'fel', 'cal', 'aval', 'mol'];
+
 /**
  * Pluralizar substantivos da língua portuguesa.
  *
@@ -100,6 +102,13 @@ module.exports = function (word, count) {
         case 'ul':
           return word.replace(/ul$/, 'uis');
       }
+    }
+
+    // Os substantivos terminados por al, el, ol, ul, troca-se o l por is.
+    // Entretanto há as chamadas "sete exceções", que fazem o plural em es.
+    // Referência: https://pt.wikipedia.org/wiki/Plural#Regras_especiais
+    if (seteExcecoes.indexOf(word) !== -1) {
+      return `${word}es`;
     }
 
     return word.replace(/l$/, 'is');


### PR DESCRIPTION
Adicionada regra para as sete exceções, que fazem o plural em es:
- mal -> males
- cônsul -> cônsules
- mel -> meles ou méis
- fel -> feles ou féis
- cal -> cales ou cais
- aval -> avales ou avais
- mol -> moles ou móis

Referência: https://pt.wikipedia.org/wiki/Plural#Regras_especiais
Issue: #2 